### PR TITLE
fix(speaker): Changement de nom de "Cap Gemini" à "Capgemini"

### DIFF
--- a/app/data/speakers.json
+++ b/app/data/speakers.json
@@ -204,7 +204,7 @@
     "featured": false,
     "name": "Slot Sponsors",
     "title": "Slot Sponsors",
-    "company": "Cap Gemini",
+    "company": "Capgemini",
     "country": "France",
     "photoUrl": "",
     "bio": ""


### PR DESCRIPTION
Changement du nom, car celui affiché n'est pas le nom officiel (et représente une autre entité qu'il est important de dissocier). 
